### PR TITLE
API Route Complete for "/api/spots" & fixed SpotImage bug

### DIFF
--- a/backend/routes/api/spots.js
+++ b/backend/routes/api/spots.js
@@ -1,13 +1,14 @@
 // backend/routes/api/session.js
-const bcrypt = require('bcryptjs');
+
 const express = require('express');
 const router = express.Router();
+const bcrypt = require('bcryptjs');
 
 const { check } = require('express-validator');
 const { handleValidationErrors } = require('../../utils/validation');
 const { Op } = require('sequelize');
 const { requireAuth, restoreUser, setTokenCookie } = require('../../utils/auth');
-const { Spot, User } = require('../../db/models');
+const { Spot, Review, Booking, SpotImage, ReviewImage, User } = require('../../db/models');
 
 
 router.get('/hello/world', function (req, res) {
@@ -15,30 +16,128 @@ router.get('/hello/world', function (req, res) {
     res.send('Hello World!!!');
 });
 
+const latlngPrecision = 6;
 
-// const { User } = require('../../db/models');
-// router.get('/set-token-cookie', async (_req, res) => {
-//   const user = await User.findOne({
-//     where: {username: 'Demo-lition'}});
-//   setTokenCookie(res, user);
-//   return res.json({ user: user });
-// });
 
 //Get all Spots
 router.get('/', async (req, res, next) => {
     try {
-        const allSpots = await Spot.findAll();
-        res.cookie('XSRF-TOKEN', req.csrfToken());
-        res.json({ Spots: allSpots });
-    } catch (err) {
-        next(err)
+
+        const spots = await Spot.findAll({
+            include: [{ model: SpotImage }, { model: Review }]
+        });
+
+        const result = spots.map(spot => {
+
+            // Preview Image
+            let previewImage = spot.SpotImages.find(image => image.isPreview);
+            previewImage = previewImage ? previewImage : { url: "No Preview Image Available" }
+
+            // Average Stars
+            const totalStars = spot.Reviews.reduce((sum, review) => sum + review.stars, 0);
+            const avgRating = spot.Reviews.length ? totalStars / spot.Reviews.length : 0;
+
+            // Create the new spot object
+            const { id, ownerId, address, city, state, country, lat, lng } = spot;
+            const { name, description, price, createdAt, updatedAt } = spot;
+
+            return {
+                id,
+                ownerId,
+                address,
+                city,
+                state,
+                country,
+                lat: lat.toFixed(latlngPrecision),
+                lng: lng.toFixed(latlngPrecision),
+                name,
+                description,
+                createdAt,
+                updatedAt,
+                avgRating: avgRating.toFixed(1),
+                previewImage: previewImage.url,
+            }
+        });
+        res.json({ Spots: result })
+    } catch (e) {
+        next(e)
     }
 });
 
 //Get all Spots by current user
+// router.get('/current', requireAuth, async (req, res, next) => {
 router.get('/current', requireAuth, async (req, res, next) => {
-    console.log("1")
-    res.json("hello world");
+
+    try {
+        // const { user } = req.body
+        const { user } = req;
+
+        const spots = await Spot.findAll({
+            include: [{ model: SpotImage }, { model: Review }],
+            where: {
+                ownerId: user.id
+            }
+        });
+
+        const result = spots.map(spot => {
+
+            // Preview Image
+            let previewImage = spot.SpotImages.find(image => image.isPreview);
+            previewImage = previewImage ? previewImage : { url: "No Preview Image Available" }
+
+            // Average Stars
+            const totalStars = spot.Reviews.reduce((sum, review) => sum + review.stars, 0);
+            const avgRating = spot.Reviews.length ? totalStars / spot.Reviews.length : 0;
+
+            // Create the new spot object
+            const { id, ownerId, address, city, state, country, lat, lng } = spot;
+            const { name, description, price, createdAt, updatedAt } = spot;
+
+            return {
+                id,
+                ownerId,
+                address,
+                city,
+                state,
+                country,
+                lat: lat.toFixed(latlngPrecision),
+                lng: lng.toFixed(latlngPrecision),
+                name,
+                description,
+                createdAt,
+                updatedAt,
+                avgRating: avgRating.toFixed(1),
+                previewImage: previewImage.url,
+            }
+        })
+
+        res.json({ Spots: result })
+    } catch (e) {
+        next(e)
+    }
 });
+
+
+//Get details of a Spot from an Id
+router.get('/:spotId', async (req, res, next) => {
+
+    try {
+        const { spotId } = req.params
+        const currentSpot = await Spot.findByPk(spotId, {
+            include: [
+                {
+                    model: SpotImage, 
+                    attributes: ['id', 'url']
+                }
+            ]
+        })
+        // const allSpots = await Spot.findAll()
+        res.json(currentSpot)
+        // res.json(allSpots)
+    } catch (e) {
+        next(e)
+    }
+})
+
 
 module.exports = router;


### PR DESCRIPTION
## Routing: /api/spots
[x] Returns all Spots

## SpotImages Table
* Edit migration to change "isPreview" to "preview"
* Edit model to change "isPreview" to "preview"
* Edit seeder to change "isPreview" to "preview"